### PR TITLE
Check if input is valid package.json format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const {
 const { getNodeJsEncodingForFile } = require('./file-encoding-matcher');
 const dependencyExtractor = require('./dependencies-extractor');
 const formatter = require('./formatter');
+const utilities = require('./utilities');
 
 program
   .version('0.0.1', '-v, --version')
@@ -55,6 +56,11 @@ const processFiles = async () => {
 
   if (!dependencies.dependencies) {
     infoMessage(chalk`No dependencies found in {blue ${input}}, exiting.`);
+    return;
+  }
+
+  if (!utilities.isValidPackageLockJson(dependencies)) {
+    infoMessage(chalk`Input {blue ${input}} not a valid {blue package-lock.json} format, exiting.`);
     return;
   }
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -43,7 +43,16 @@ const getUniquesByNameAndVersion = (array) => {
   return result;
 };
 
+const isValidPackageLockJson = input => typeof input !== 'undefined'
+    && typeof input.dependencies !== 'undefined'
+    && !Object.entries(input.dependencies).find(
+      entry => typeof entry === 'undefined'
+        || typeof entry[1] === 'undefined'
+        || typeof entry[1].version === 'undefined',
+    );
+
 module.exports = {
   sortByNameAndVersionCaseInsensitive,
   getUniquesByNameAndVersion,
+  isValidPackageLockJson,
 };

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -108,3 +108,8 @@ test('getUniquesByNameAndVersion called on list with duplicated (upper cased) co
       { [NAME_KEY]: 'package_C', [VERSION_KEY]: 'C1_THREETIMES.0.0' },
     ]);
 });
+
+test('isValidPackageLockJson returns false if input is incorrect', () => {
+  const input = { dependencies: { 'some package': { } } };
+  expect(utilities.isValidPackageLockJson(input)).toBe(false);
+});


### PR DESCRIPTION
Using an input file which format doesn't satisfy the `package-lock.json` format results in following error

```
(node:19227) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toUpperCase' of undefined
    at array.forEach (/Users/phnl310230095/projects/npm-dependencies-extractor/src/utilities.js:34:30)
    at Array.forEach (<anonymous>)
    at Object.getUniquesByNameAndVersion (/Users/phnl310230095/projects/npm-dependencies-extractor/src/utilities.js:32:9)
    at Object.getFlatListOfDependencies (/Users/phnl310230095/projects/npm-dependencies-extractor/src/dependencies-extractor.js:33:6)
    at processFiles (/Users/phnl310230095/projects/npm-dependencies-extractor/src/index.js:67:60)
```

Current pull request will check for valid input